### PR TITLE
Changed the title of the webpage to CourseBook. Fixes #8

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Create a course, add students, then easily pick a random student, or create a list of random pairs of students from your roster."
     />
     <link rel="apple-touch-icon" href="logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>CourseBook</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
When I first started the app, I noticed that the title was the generic "React App". This pull request fixes this.